### PR TITLE
docs: fix README separated typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Updated nightly.
 
 ### Filer Metadata
 
-Information on every SEC Submissions Filer. For convenience, filers are seperated into listed & unlisted. Listed means has a ticker. Unlisted includes individuals.
+Information on every SEC Submissions Filer. For convenience, filers are separated into listed & unlisted. Listed means has a ticker. Unlisted includes individuals.
 
 Updated daily at 4:00 am ET. (2:00 AM ET is when the submissions.zip file is updated)
 


### PR DESCRIPTION
## Summary
- fix a README typo: `seperated` -> `separated`
- normalize the README final newline

## Validation
- `rg -n 'seperated|separated|listed|unlisted' readme.md`
- `git diff --check`

No runtime tests were run because this only changes README prose and does not alter commands, generated output, configuration, or code.